### PR TITLE
Randomly generated tree tiles

### DIFF
--- a/src/ConicalTree.js
+++ b/src/ConicalTree.js
@@ -6,8 +6,6 @@ import { TILE_SIZE } from './Constants.js';
 
 export default class Tree {
   constructor(x, z) {
-    const centerX = x + TILE_SIZE / 2;
-    const centerZ = z + TILE_SIZE / 2;
     // Tree Textures
     const trunkTexture = new THREE.TextureLoader().load(TrunkTexture);
     const leavesTexture = new THREE.TextureLoader().load(LeafTexture);
@@ -16,13 +14,14 @@ export default class Tree {
     const cylinderGeometry = new THREE.CylinderGeometry(0.25, 0.25, 2, 30);
     const cylinderMaterial = new THREE.MeshBasicMaterial({ map: trunkTexture });
     const trunk = new THREE.Mesh( cylinderGeometry, cylinderMaterial );
-    trunk.position.set(centerX, 1, centerZ);
+    // we are working on a grid of 5, must compensate for a tree being placed on an edge (0.5)
+    trunk.position.set(x + 0.5, 1, z + 0.5);
 
     // Conical leaves
     const coneGeometry = new THREE.ConeGeometry( 1, 2, 20 );
     const coneMaterial = new THREE.MeshBasicMaterial({ map: leavesTexture });
     const leaves = new THREE.Mesh( coneGeometry, coneMaterial );
-    leaves.position.set(centerX, trunk.position.y + 1.75, centerZ);
+    leaves.position.set(x + 0.5, trunk.position.y + 1.75, z + 0.5);
 
     const group = new THREE.Object3D();
     group.add(trunk);

--- a/src/Prefabs.js
+++ b/src/Prefabs.js
@@ -1,0 +1,53 @@
+import * as THREE from 'three';
+
+import { MAP_SIZE, TILE_SIZE } from './Constants.js';
+import { MathUtils } from 'three';
+
+import ConicalTree from './ConicalTree.js';
+
+export default class TreeTile {
+  // @param x - world space position x
+  // @param z - world space position z
+  constructor(x, z) {
+    // center of tile
+    const centerX = Math.floor(TILE_SIZE / 2);
+    const centerZ = Math.floor(TILE_SIZE / 2);
+    // tile group
+    const group = new THREE.Object3D();
+
+    // try to place at least 2 trees, maximum 5
+    const randNum = MathUtils.randInt(2, 5);
+
+    // setup array to keep track of local trees
+    let groupedTrees = []
+    for(let i = 0; i < TILE_SIZE; i++) {
+      groupedTrees[i] = new Array(TILE_SIZE)
+    }
+
+    // make randNum trees
+    for(let i = 0; i < randNum; i++) {
+      // random distance from center
+      const randX = MathUtils.randInt(-2, 2);
+      const randZ = MathUtils.randInt(-2, 2);
+      let localX = centerX + randX;
+      let localZ = centerZ + randZ;
+
+      // tree already exists at location, skip
+      if(groupedTrees[localX][localZ]) {
+        continue;
+      }
+
+      if((localX + x > MAP_SIZE || localZ + z > MAP_SIZE) || (localX + x < 0 || localZ + z < 0)) {
+        // tree ended up out of grounds, skip it
+        continue
+      } else {
+        // add tree to tile group
+        group.add(new ConicalTree(localX + x, localZ + z).group);
+        // set tree exists "here"
+        groupedTrees[localX][localZ] = true
+      }
+    }
+
+    this.group = group
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import ForestTextureNY from './images/skybox/ny.jpg';
 import ForestTextureNZ from './images/skybox/nz.jpg';
 
 import ConicalTree from './ConicalTree.js';
+import TreeTile from './Prefabs.js';
 import { GridHelper, MathUtils } from 'three';
 
 // Scene + camera setup
@@ -35,9 +36,9 @@ scene.add(axesHelper);
 const simplex = new SimplexNoise();
 let layout = [];
 
-for (let z = 0; z < GRID_SIZE; z++) {
+for (let z = 0; z < MAP_SIZE; z += TILE_SIZE) {
   layout[z] = new Array(GRID_SIZE);
-  for (let x = 0; x < GRID_SIZE; x++) {
+  for (let x = 0; x < MAP_SIZE; x += TILE_SIZE) {
     layout[z][x] = simplex.noise2D(x, z);
   }
 }
@@ -56,12 +57,15 @@ scene.background = skyboxTexture;
 // Add ground
 const ground = new Ground;
 scene.add(ground.mesh);
+console.log("ground pos: " + ground.position)
 
-for (let z = 0; z < GRID_SIZE; z++) {
-  for (let x = 0; x < GRID_SIZE; x++) {
+// entire map is 10 "tiles" that are size 5x5
+for (let z = 0; z < MAP_SIZE; z += TILE_SIZE) {
+  for (let x = 0; x < MAP_SIZE; x += TILE_SIZE) {
     if (layout[z][x] > 0.4) {
-      let randPos = MathUtils.randInt(1, 3) + 0.5;
-      scene.add(new ConicalTree(x * TILE_SIZE + randPos, z * TILE_SIZE + randPos).group);
+      console.log("Setting up tree tile at " + x + " " + z)
+      // TreeTile randomly places trees within the 5x5 tile based on world coords x,z
+      scene.add(new TreeTile(x, z).group);
     }
   }
 }


### PR DESCRIPTION
Instead of spawning trees randomly across the world space, this introduces randomly generating each 5x5 tile.
The map is a 10x10 grid of tiles that are themselves 5x5 units. The noise generator now generates across this larger tiles, and will spawn a randomly generated tile if there is enough noise.

Each tile can spawn anywhere from 2 to 5 trees within it. Leaves will overlap but trunks will not. 

Different scenes, refreshed page each time:
![image](https://user-images.githubusercontent.com/49186122/134302776-e16b7324-17fe-443a-8f95-12190cbd1ccf.png)
![image](https://user-images.githubusercontent.com/49186122/134302816-611c5b6c-62eb-401d-bbe9-d9921fe09bff.png)
![image](https://user-images.githubusercontent.com/49186122/134302838-8abd4531-fd2b-4cca-bbfc-2f223a59d4ec.png)


